### PR TITLE
Part 4: display saved filename on form validation errors

### DIFF
--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -10,6 +10,8 @@ export default class extends Controller {
   }
 
   updateLabel() {
+    // temp debug
+    console.log("=== updateLabel ===");
     // Check if a file is already selected (after validation error)
     if (this.hasHiddenFieldTarget && this.hiddenFieldTarget.value) {
       this.labelTarget.textContent = this.inputTarget.dataset.filename;
@@ -19,6 +21,8 @@ export default class extends Controller {
   }
 
   handleNewFileSelection() {
+    // temp debug
+    console.log("=== handleNewFileSelection ===");
     // When user selects a new file, update the label
     if (this.inputTarget.files.length > 0) {
       this.labelTarget.textContent = this.inputTarget.files[0].name;

--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -1,23 +1,21 @@
 import { Controller } from "@hotwired/stimulus";
 
-// FIXME: Displaying selected file name in quotes
+// TODO: Remove hidden field, just need defaultTextValue
 // Connects to data-controller="file-upload"
 export default class extends Controller {
   static targets = ["input", "hiddenField", "label"];
+  static values = {
+    defaultText: { type: String, default: 'Choose file...' }
+  }
 
   connect() {
+    console.log("=== connect ===");
     this.updateLabel();
   }
 
   updateLabel() {
-    // temp debug
-    console.log("=== updateLabel ===");
-    // Check if a file is already selected (after validation error)
-    if (this.hasHiddenFieldTarget && this.hiddenFieldTarget.value) {
-      this.labelTarget.textContent = this.inputTarget.dataset.filename;
-    } else {
-      this.labelTarget.textContent = "Choose a file";
-    }
+    console.log(`=== updateLabel: ${this.defaultTextValue} ===`);
+    this.labelTarget.textContent = this.defaultTextValue
   }
 
   handleNewFileSelection() {
@@ -25,8 +23,10 @@ export default class extends Controller {
     console.log("=== handleNewFileSelection ===");
     // When user selects a new file, update the label
     if (this.inputTarget.files.length > 0) {
+      console.log(`=== handleNewFileSelection: native file selection: ${this.inputTarget.files[0].name} ===`);
       this.labelTarget.textContent = this.inputTarget.files[0].name;
     } else {
+      console.log(`=== handleNewFileSelection: no file selected, delegating to updateLabel ===`);
       this.updateLabel(); // Reset label if no file selected
     }
   }

--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus";
+
+// FIXME: Displaying selected file name in quotes
+// Connects to data-controller="file-upload"
+export default class extends Controller {
+  static targets = ["input", "hiddenField", "label"];
+
+  connect() {
+    this.updateLabel();
+  }
+
+  updateLabel() {
+    // Check if a file is already selected (after validation error)
+    if (this.hasHiddenFieldTarget && this.hiddenFieldTarget.value) {
+      this.labelTarget.textContent = this.inputTarget.dataset.filename;
+    } else {
+      this.labelTarget.textContent = "Choose a file";
+    }
+  }
+
+  handleNewFileSelection() {
+    // When user selects a new file, update the label
+    if (this.inputTarget.files.length > 0) {
+      this.labelTarget.textContent = this.inputTarget.files[0].name;
+    } else {
+      this.updateLabel(); // Reset label if no file selected
+    }
+  }
+}

--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -2,18 +2,31 @@ import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="file-upload"
 export default class extends Controller {
-  static targets = ["input", "label"];
+  static targets = ["input", "label", "button"];
   static values = {
     defaultText: { type: String, default: 'Choose file...' }
   }
 
   connect() {
+    this.buttonTarget.addEventListener("keydown", this.handleKeyDown);
     this.updateLabel();
+  }
+
+  disconnect() {
+    this.buttonTarget.removeEventListener("keydown", this.handleKeyDown);
   }
 
   updateLabel() {
     this.labelTarget.textContent = this.defaultTextValue
   }
+
+  // Accessibility for keyboard users hitting Enter on custom file input button
+  handleKeyDown = (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      this.inputTarget.click(); // Trigger hidden file input
+    }
+  };
 
   // When user selects a new file, update the label based on native file input selection
   handleNewFileSelection() {

--- a/app/javascript/controllers/file_upload_controller.js
+++ b/app/javascript/controllers/file_upload_controller.js
@@ -1,32 +1,25 @@
 import { Controller } from "@hotwired/stimulus";
 
-// TODO: Remove hidden field, just need defaultTextValue
 // Connects to data-controller="file-upload"
 export default class extends Controller {
-  static targets = ["input", "hiddenField", "label"];
+  static targets = ["input", "label"];
   static values = {
     defaultText: { type: String, default: 'Choose file...' }
   }
 
   connect() {
-    console.log("=== connect ===");
     this.updateLabel();
   }
 
   updateLabel() {
-    console.log(`=== updateLabel: ${this.defaultTextValue} ===`);
     this.labelTarget.textContent = this.defaultTextValue
   }
 
+  // When user selects a new file, update the label based on native file input selection
   handleNewFileSelection() {
-    // temp debug
-    console.log("=== handleNewFileSelection ===");
-    // When user selects a new file, update the label
     if (this.inputTarget.files.length > 0) {
-      console.log(`=== handleNewFileSelection: native file selection: ${this.inputTarget.files[0].name} ===`);
       this.labelTarget.textContent = this.inputTarget.files[0].name;
     } else {
-      console.log(`=== handleNewFileSelection: no file selected, delegating to updateLabel ===`);
       this.updateLabel(); // Reset label if no file selected
     }
   }

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -26,6 +26,8 @@
     <%= form.date_field :incurred_on, class: ["block shadow-sm rounded-md border px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": expense_report.errors[:incurred_on].none?, "border-red-400 focus:outline-red-600": expense_report.errors[:incurred_on].any?}] %>
   </div>
 
+  <%# If a file is attached but not persisted, it means user submitted the form with a selected file but also had validation error(s) %>
+  <%# If that's the case, we update the custom file input label with the file name from the model so user realizes we still have their file %>
   <div class="my-5"
       data-controller="file-upload"
       data-file-upload-default-text-value="<%= expense_report.receipt.attached? && !expense_report.receipt.persisted? ? expense_report.receipt.blob.filename : "Choose a file" %>">
@@ -44,14 +46,13 @@
             data: { file_upload_target: "input", action: "change->file-upload#handleNewFileSelection" },
             class: "absolute inset-0 w-full opacity-0 cursor-pointer" %>
 
-      <%# Styled Text-like Input (mimicking a text field) %>
+      <%# Custom file input selector that will render on top of the hidden native file input %>
+      <%# This allows us to target it with JavaScript to pre-populate a file name if user previously selected one %>
+      <%# and then submitted the form with validation errors %>
       <div data-file-upload-target="label"
           class="flex-1 px-3 py-2 text-gray-700 truncate">
         <%# Label population is handled by JavaScript: app/javascript/controllers/file_upload_controller.js  %>
       </div>
-
-      <%# TODO: Could this be an actual button for accessibility? %>
-      <%# Styled Button %>
       <div class="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded-r-md cursor-pointer hover:bg-gray-300">
         Browse
       </div>

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -35,7 +35,7 @@
     <%# Let's hang on to that id for them in a hidden field so file will be persisted on next successful form submission %>
     <%# This works to reference signed_id because of enabling Active Storage Direct Uploads, the blob is there in the database and in the file system %>
     <% if expense_report.receipt.attached? && !expense_report.receipt.persisted? %>
-      <%= form.hidden_field :receipt, value: expense_report.receipt.signed_id, data: { file_upload_target: "hiddenField" } %>
+      <%= form.hidden_field :receipt, value: expense_report.receipt.signed_id %>
     <% end %>
 
     <div class="relative w-full flex items-center border border-gray-300 bg-gray-50 rounded-md shadow-sm">

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -36,19 +36,21 @@
       <%= form.hidden_field :receipt, value: expense_report.receipt.signed_id, data: { file_upload_target: "hiddenField" } %>
     <% end %>
 
-    <div class="relative w-full">
-      <%# Actual file input (hidden but still functional) %>
+    <div class="relative w-full flex items-center border border-gray-300 bg-gray-50 rounded-md shadow-sm">
+      <%# Native file input (hidden but still functional) %>
       <%= form.file_field :receipt, direct_upload: true,
             data: { file_upload_target: "input", filename: expense_report.receipt.filename, action: "change->file-upload#handleNewFileSelection" },
             class: "absolute inset-0 w-full opacity-0 cursor-pointer" %>
 
-      <%# Custom label that mimics a file input display %>
-      <%# Tailwind’s file:* variant allows you to style just the button part - FIXME not working style-wise for custom div %>
+      <%# Styled Text-like Input (mimicking a text field) %>
       <div data-file-upload-target="label"
-          class="block w-full cursor-pointer rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-gray-700 shadow-sm
-                  file:mr-4 file:rounded-md file:border file:border-gray-400 file:bg-gray-200 file:px-4 file:py-1.5
-                  file:text-gray-800 file:font-medium file:cursor-pointer hover:file:bg-gray-300 focus:outline-blue-600">
+          class="flex-1 px-3 py-2 text-gray-700 truncate">
         <%= expense_report.receipt.attached? && !expense_report.receipt.persisted? ? expense_report.receipt.filename.to_s : "Choose a file" %>
+      </div>
+
+      <%# Styled Button %>
+      <div class="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded-r-md cursor-pointer hover:bg-gray-300">
+        Browse
       </div>
     </div>
 

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -45,7 +45,7 @@
       <%# Styled Text-like Input (mimicking a text field) %>
       <div data-file-upload-target="label"
           class="flex-1 px-3 py-2 text-gray-700 truncate">
-        <%= expense_report.receipt.attached? && !expense_report.receipt.persisted? ? expense_report.receipt.filename.to_s : "Choose a file" %>
+        <%# Label population is handled by JavaScript: app/javascript/controllers/file_upload_controller.js  %>
       </div>
 
       <%# Styled Button %>

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -53,7 +53,9 @@
           class="flex-1 px-3 py-2 text-gray-700 truncate">
         <%# Label population is handled by JavaScript: app/javascript/controllers/file_upload_controller.js  %>
       </div>
-      <button type="button" class="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded-r-md cursor-pointer hover:bg-gray-300">
+      <button type="button"
+          data-file-upload-target="button"
+          class="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded-r-md cursor-pointer hover:bg-gray-300">
         Browse
       </button>
     </div>

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -26,25 +26,33 @@
     <%= form.date_field :incurred_on, class: ["block shadow-sm rounded-md border px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": expense_report.errors[:incurred_on].none?, "border-red-400 focus:outline-red-600": expense_report.errors[:incurred_on].any?}] %>
   </div>
 
-  <div class="my-5">
-    <%# Tailwind’s file:* variant allows you to style just the button part %>
+  <div class="my-5" data-controller="file-upload">
     <%= form.label :receipt %>
-    <%= form.file_field :receipt, direct_upload: true, class: "block w-full cursor-pointer rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-gray-700 shadow-sm file:mr-4 file:rounded-md file:border file:border-gray-400 file:bg-gray-200 file:px-4 file:py-1.5 file:text-gray-800 file:font-medium file:cursor-pointer hover:file:bg-gray-300 focus:outline-blue-600" %>
 
     <%# If the receipt is attached but not persisted it means user previously attempted to upload but encountered form validation errors %>
     <%# Let's hang on to that id for them in a hidden field so file will be persisted on next successful form submission %>
     <%# This works to reference signed_id because of enabling Active Storage Direct Uploads, the blob is there in the database and in the file system %>
-    <% if expense_report.receipt.attached? && !expense_report.receipt.persisted?%>
-      <%= form.hidden_field :receipt, value: expense_report.receipt.signed_id %>
+    <% if expense_report.receipt.attached? && !expense_report.receipt.persisted? %>
+      <%= form.hidden_field :receipt, value: expense_report.receipt.signed_id, data: { file_upload_target: "hiddenField" } %>
     <% end %>
 
-    <%# Display to user their current attachment if there is one - this causes issues if there are validation errors, for example on update %>
-    <%# Cannot get a signed_id for a new record %>
-    <%# It's an issue on edit: When there already is an attachment, user selects a new one, and has some other validation error in the form %>
-    <%# Also on issue on new: User selects a file and submits form with some other validation error %>
-    <%# Partial solution: Use `persisted?` rather than `attached?` so it doesn't attempt to render download link for file that wasn't actually uploaded %>
-    <%# BUT this introduces a new problem: If user previously submitted form with an attachment and validation errors, the file selection is lost %>
-    <%# and they have to select file again - bad UX. %>
+    <div class="relative w-full">
+      <%# Actual file input (hidden but still functional) %>
+      <%= form.file_field :receipt, direct_upload: true,
+            data: { file_upload_target: "input", filename: expense_report.receipt.filename, action: "change->file-upload#handleNewFileSelection" },
+            class: "absolute inset-0 w-full opacity-0 cursor-pointer" %>
+
+      <%# Custom label that mimics a file input display %>
+      <%# Tailwind’s file:* variant allows you to style just the button part - FIXME not working style-wise for custom div %>
+      <div data-file-upload-target="label"
+          class="block w-full cursor-pointer rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-gray-700 shadow-sm
+                  file:mr-4 file:rounded-md file:border file:border-gray-400 file:bg-gray-200 file:px-4 file:py-1.5
+                  file:text-gray-800 file:font-medium file:cursor-pointer hover:file:bg-gray-300 focus:outline-blue-600">
+        <%= expense_report.receipt.attached? && !expense_report.receipt.persisted? ? expense_report.receipt.filename.to_s : "Choose a file" %>
+      </div>
+    </div>
+
+    <%# Display to user their current attachment if there is one %>
     <% if expense_report.receipt.persisted? %>
       <div class="mt-2">
         <strong class="block font-medium mb-1">Current Receipt:</strong>

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -26,7 +26,9 @@
     <%= form.date_field :incurred_on, class: ["block shadow-sm rounded-md border px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": expense_report.errors[:incurred_on].none?, "border-red-400 focus:outline-red-600": expense_report.errors[:incurred_on].any?}] %>
   </div>
 
-  <div class="my-5" data-controller="file-upload">
+  <div class="my-5"
+      data-controller="file-upload"
+      data-file-upload-default-text-value="<%= expense_report.receipt.attached? && !expense_report.receipt.persisted? ? expense_report.receipt.blob.filename : "Choose a file" %>">
     <%= form.label :receipt %>
 
     <%# If the receipt is attached but not persisted it means user previously attempted to upload but encountered form validation errors %>
@@ -39,7 +41,7 @@
     <div class="relative w-full flex items-center border border-gray-300 bg-gray-50 rounded-md shadow-sm">
       <%# Native file input (hidden but still functional) %>
       <%= form.file_field :receipt, direct_upload: true,
-            data: { file_upload_target: "input", filename: expense_report.receipt.filename, action: "change->file-upload#handleNewFileSelection" },
+            data: { file_upload_target: "input", action: "change->file-upload#handleNewFileSelection" },
             class: "absolute inset-0 w-full opacity-0 cursor-pointer" %>
 
       <%# Styled Text-like Input (mimicking a text field) %>
@@ -48,6 +50,7 @@
         <%# Label population is handled by JavaScript: app/javascript/controllers/file_upload_controller.js  %>
       </div>
 
+      <%# TODO: Could this be an actual button for accessibility? %>
       <%# Styled Button %>
       <div class="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded-r-md cursor-pointer hover:bg-gray-300">
         Browse

--- a/app/views/expense_reports/_form.html.erb
+++ b/app/views/expense_reports/_form.html.erb
@@ -53,9 +53,9 @@
           class="flex-1 px-3 py-2 text-gray-700 truncate">
         <%# Label population is handled by JavaScript: app/javascript/controllers/file_upload_controller.js  %>
       </div>
-      <div class="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded-r-md cursor-pointer hover:bg-gray-300">
+      <button type="button" class="px-4 py-2 bg-gray-200 text-gray-800 font-medium rounded-r-md cursor-pointer hover:bg-gray-300">
         Browse
-      </div>
+      </button>
     </div>
 
     <%# Display to user their current attachment if there is one %>

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -51,9 +51,13 @@ bin/dev
   - i.e. because of direct upload, this `signed_id` corresponds to an uploaded file in storage, so if submitted again, Rails will be able to associate this file to the expense_report model
 
 ### Solution Part 4
-- Fourth part: Stimulus controller (or some other logic) to let the user know that we still have their file name in memory so they don't need to select the file again (because otherwise, user doesn't realize that we've "saved" the file for them).
-  - Note that filename is available on the model in memory, even if validation error: `expense_report.receipt.blob.filename`
-  - Might need some JavaScript to manipulate the native file input
+- Fourth part: Let the user know that we still have their file name in memory so they don't need to select the file again (because otherwise, user doesn't realize that we've "saved" the file for them).
+  - Note that filename is available on the model in memory, even if validation error: `expense_report.receipt.filename`
+  - Might need some JavaScript to manipulate the native file input because unfortunately, can't simply set it's `value` property (not allowed, part of spec, reference MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#notes)
+  - Therefore we'll need to hide the native file input and build a custom one for display purposes, and manipulate it with JavaScript - which in Rails is done with Stimulus controllers (ref: my previous post on stimulus how to)
+  - If a previously uploaded file exists (but isn't persisted) - label displays the filename instead of `"Choose a file"`.
+  - This makes it feel like the file is already selected without interfering with browser behavior
+  - If the user selects a new file - label updates dynamically to show the new filename and new file is uploaded normally and replaces the old one.
 
 ### Solution Part 5
 - Fifth part (optional): Extract to partial for re-usability if project has many places with file uploads

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -58,7 +58,7 @@ bin/dev
 ### Solution Part 4
 - Fourth part: Let the user know that we still have their file name in memory so they don't need to select the file again (because otherwise, user doesn't realize that we've "saved" the file for them).
   - Note that filename is available on the model in memory, even if validation error: `expense_report.receipt.filename`
-  - Might need some JavaScript to manipulate the native file input because unfortunately, can't simply set it's `value` property (not allowed, part of spec, reference MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#notes)
+  - Will need some JavaScript to manipulate the native file input because unfortunately, can't simply set it's `value` property (not allowed, part of spec, reference MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#notes)
   - Therefore we'll need to hide the native file input and build a custom one for display purposes, and manipulate it with JavaScript - which in Rails is done with Stimulus controllers (ref: my previous post on stimulus how to)
   - If a previously uploaded file exists (but isn't persisted) - label displays the filename instead of `"Choose a file"`.
   - This makes it feel like the file is already selected without interfering with browser behavior

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -58,11 +58,13 @@ bin/dev
 ### Solution Part 4
 - Fourth part: Let the user know that we still have their file name in memory so they don't need to select the file again (because otherwise, user doesn't realize that we've "saved" the file for them).
   - Note that filename is available on the model in memory, even if validation error: `expense_report.receipt.filename`
-  - Will need some JavaScript to manipulate the native file input because unfortunately, can't simply set it's `value` property (not allowed, part of spec, reference MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#notes)
+  - Unfortunately, can't simply set the native file input's `value` property (not allowed, part of spec, reference MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#notes)
   - Therefore we'll need to hide the native file input and build a custom one for display purposes, and manipulate it with JavaScript - which in Rails is done with Stimulus controllers (ref: my previous post on stimulus how to)
+  - The custom file input consists of a label which looks like a text input to show file name, and a button to trigger file selection
   - If a previously uploaded file exists (but isn't persisted) - label displays the filename instead of `"Choose a file"`.
   - This makes it feel like the file is already selected without interfering with browser behavior
   - If the user selects a new file - label updates dynamically to show the new filename and new file is uploaded normally and replaces the old one.
+  - Also add accessibility to ensure keyboard user that focuses on custom file input button and hits Enter -> trigger underlying native file input selection
 
 ### Solution Part 5
 - Fifth part (optional): Extract to partial for re-usability if project has many places with file uploads


### PR DESCRIPTION
- **display filename as if user had just selected it on validation errors**
- **update notes on js solution**
- **style custom file input**
- **remove uneeded erb population of custom file input text because its handled by stimulus**
- **fix quotes in selected file name display and simplify js logic**
- **simplify remove hidden field target for stimulus**
- **add some further explanations in form partial wrt custom file input**
- **make custom file input browse a button so it can accept keyboard focus**
- **accessibility for button as custom file input selector**
